### PR TITLE
NoMethodError: undefined method `unparsed_value'

### DIFF
--- a/lib/unione/sender.rb
+++ b/lib/unione/sender.rb
@@ -48,7 +48,7 @@ module Unione
         message: {
           subject: mail.subject,
           from_email: mail.from.first,
-          from_name: sender_name(mail.From.unparsed_value),
+          from_name: sender_name(mail.From.instance_variable_get(:@unparsed_value)),
           recipients: recipients,
           body: { html: mail_body },
           inline_attachments: inline_attachments


### PR DESCRIPTION
NoMethodError: undefined method `unparsed_value' for
#<Mail::FromField:0x00007fa255416780>
ruby-2.4.3/gems/mail-2.7.0/lib/mail/field.rb:237:in `method_missing'